### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Include the header in your project
     #include "MasterServerFunctions.h"
 
 
-####Initalize the plugin
+#### Initalize the plugin
 
 This should ideally be in your GameInstance class.
 ```cpp


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
